### PR TITLE
Allow build on Haiku target

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -61,6 +61,10 @@ ifneq (,$(findstring unix,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro.so
 	LDFLAGS += -shared -Wl,--version-script=$(ROOT_DIR)/link.T -Wl,--no-undefined
 
+ifneq (,$(findstring Haiku,$(shell uname -s)))
+	LDFLAGS += -lnetwork
+endif
+
 	fpic = -fPIC
 
    ifeq ($(FORCE_GLES),1)


### PR DESCRIPTION
Network functions are in libnetwork, a Haiku peculiarity. This allows the core to build.