### PR TITLE
Bump minimum android api level to 21

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,3 +1,3 @@
 APP_ABI := all
-APP_PLATFORM := android-9
+APP_PLATFORM := android-21
 


### PR DESCRIPTION
Some posix functions used by sqlite3 are not available until api
level 21.