### PR TITLE
Remove gles define that was added in recent ndk versions

### DIFF
--- a/deps/libretro-common/include/glsm/glsm.h
+++ b/deps/libretro-common/include/glsm/glsm.h
@@ -32,7 +32,6 @@
 RETRO_BEGIN_DECLS
 
 #ifdef HAVE_OPENGLES2
-typedef GLfloat GLdouble;
 typedef GLclampf GLclampd;
 #endif
 


### PR DESCRIPTION
This allows the core to continue to compile, but it still doesn't run correctly.