### PR TITLE
Fix compilation errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ log.txt
 *.exe
 *.dll
 *.pyc
+/Makefile
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ add_executable(
     src/renderer.c
     src/sign.c
     src/world.c
-    deps/glew/src/glew.c
     deps/lodepng/lodepng.c
     deps/noise/noise.c
     deps/sqlite/sqlite3.c
@@ -26,9 +25,7 @@ add_definitions(-std=c99 -O3)
 add_definitions(-DHAVE_OPENGL)
 add_definitions(-DHAVE_LIBCURL)
 
-add_subdirectory(deps/glfw)
 include_directories(deps/glew/include)
-include_directories(deps/glfw/include)
 include_directories(deps/libretro-common/include)
 include_directories(deps/lodepng)
 include_directories(deps/noise)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ include_directories(deps/lodepng)
 include_directories(deps/noise)
 include_directories(deps/sqlite)
 include_directories(deps/tinycthread)
+include_directories(libretro)
 
 if(MINGW)
     set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH}

--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,0 @@
-include Makefile.libretro

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ the installation:
 
 #### Linux (Ubuntu)
 
-    sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev
+    sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev libglfw-dev
     sudo apt-get build-dep glfw
 
 #### Windows

--- a/src/main.c
+++ b/src/main.c
@@ -156,12 +156,12 @@ typedef struct {
 #define signbit(x) (_copysign(1.0, x) < 0)
 #endif
 
-static INLINE float fminf_internal(float a, float b)
+static inline float fminf_internal(float a, float b)
 {
   return a < b ? a : b;
 }
 
-static INLINE float fmaxf_internal(float a, float b)
+static inline float fmaxf_internal(float a, float b)
 {
   return a > b ? a : b;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -2,6 +2,7 @@
 #define _util_h_
 
 #include "config.h"
+#include <stdio.h>
 
 #define PI 3.14159265359
 #define DEGREES(radians) ((radians) * 180 / PI)


### PR DESCRIPTION
I thought it might be nice if the project could compile. The fixes on this branch are pretty obvious; don't point at files and directories that don't exist, don't assume stderr is available without including stdio.h, don't include a Makefile that gets overwritten by the build process.

After that, I'm still stuck with an error:

```
[  5%] Linking C executable craft
/usr/bin/ld: CMakeFiles/craft.dir/src/renderer.c.o: undefined reference to symbol 'glLogicOp'
/usr/bin/ld: //usr/lib/x86_64-linux-gnu/libGL.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/craft.dir/build.make:310: craft] Error 1
make[1]: *** [CMakeFiles/Makefile2:76: CMakeFiles/craft.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```

I'm guessing the order of the -l flags is incorrect, but I'm not sure where to look for those at the moment.