### PR TITLE
Fix the emscripten build by removing a special case.

### DIFF
--- a/deps/libretro-common/include/glsm/glsm.h
+++ b/deps/libretro-common/include/glsm/glsm.h
@@ -32,7 +32,7 @@
 RETRO_BEGIN_DECLS
 
 #ifdef HAVE_OPENGLES2
-#if defined (IOS) || defined(EMSCRIPTEN) || !defined(GL_NV_path_rendering)
+#if defined (IOS) || !defined(GL_NV_path_rendering)
 typedef GLfloat GLdouble;
 #endif
 typedef GLclampf GLclampd;


### PR DESCRIPTION
The older version of libretro-common that's been vendored into this repository has an outdated typedef that's no longer needed for Emscripten.